### PR TITLE
Listing all the medicine in a medical shop functionality.

### DIFF
--- a/backend/pharmacy/api/views/medical/medicine.py
+++ b/backend/pharmacy/api/views/medical/medicine.py
@@ -47,8 +47,10 @@ class MedicineViewByID(generics.CreateAPIView):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         try:
-            medicine = Medicine.objects.get(pk=pk)
+            # Get the medicine list of that medical shop
+            medicine = Medicine.objects.filter(medicalId=pk)
+            # medicine = Medicine.objects.get(pk=pk)
         except Medicine.DoesNotExist:
             raise Http404
-        serializer = MedicineSerializer(medicine)
+        serializer = MedicineSerializer(medicine, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/docs/medicalUserDoc.md
+++ b/docs/medicalUserDoc.md
@@ -479,3 +479,48 @@ response = requests.request("POST", reqUrl, data=payload,  headers=headersList)
 >   }
 > ]
 > ```
+
+
+### Getting all the medicines listed by a medical shop
+> **Note:** You have to perform a `GET` request on `/mymedical/<medicalId>/` endpoint with the access token of the owner of medical shop.
+> **Code Example:**
+> ```python
+> import requests
+> 
+> reqUrl = "http://127.0.0.1:8000/api/mymedical/5/"
+> 
+> headersList = {
+>  "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjQ2MzIxNDQ0LCJpYXQiOjE2NDYzMTk2NDQsImp0aSI6IjU2Yzg1YzU2MTE3MjRmMDQ5ZWQ1NjUzN2FmZGYwY2I1IiwidXNlcl9pZCI6MSwidXNlcm5hbWUiOiJndWxzaGFuIiwiZW1haWwiOiIifQ.Zwc633Sj6-uxgCrHD1dHiECzJ4-MxrlzprKXNIgD0zI" 
+> }
+> 
+> response = requests.request("GET", reqUrl, headers=headersList)
+> 
+> ```
+
+> **Response:**
+> ```json
+> [
+>   {
+>     "medicineId": 6,
+>     "createdAt": "2022-03-03T15:00:20.759218Z",
+>     "name": "Dolo",
+>     "description": "Fever",
+>     "price": 100,
+>     "quantity": 100,
+>     "medicalId": 5,
+>     "user": 1
+>   },
+>   {
+>     "medicineId": 8,
+>     "createdAt": "2022-03-03T15:05:11.665198Z",
+>     "name": "Gulshan",
+>     "description": "Flutter Mastering blog",
+>     "price": 1,
+>     "quantity": 15,
+>     "medicalId": 5,
+>     "user": 1
+>   }
+> ]
+> ```
+
+>> 200 OK stands for successfull request.


### PR DESCRIPTION
Fixed the earlier bug.

The underlying issue was, I was looking for pk=pk in my code. But it's wrong, in the case of pk=pk, django looks for the medicine of specific medicineId not medical Id.

So in this pull request, I have corrected the comparison to,
```python 
            medicine = Medicine.objects.filter(medicalId=pk)
```